### PR TITLE
Уточнение платформы запуска

### DIFF
--- a/DATA/Doom/C2DOOM/links.md
+++ b/DATA/Doom/C2DOOM/links.md
@@ -7,7 +7,7 @@
 
 [Symbian. **CORE** Версия 1.14 для S90](/files/c2-doom-core-114.sisx) (2 МБ)
 
-[Symbian. **CORE** Версия 1.03 для S80](/files/c2doom_s80(1.03).sis) (0.4 МБ)
+[Symbian. **CORE** Версия 1.03 для S80 v1](/files/c2doom_s80(1.03).sis) (0.4 МБ)
 
 [Symbian. **CORE** Версия 1.15 для S90](/files/c2doom_core(1.15).sisx) (1.9 МБ)
 


### PR DESCRIPTION
C2doom для s80 не работает на s80v2, падает с ошибкой после загрузки.