### PR TITLE
Raze Touch: Windows -> Android

### DIFF
--- a/DATA/Shadow_Warrior/Raze_Touch/os.txt
+++ b/DATA/Shadow_Warrior/Raze_Touch/os.txt
@@ -1,1 +1,1 @@
-Windows
+Android


### PR DESCRIPTION
Сам порт игр на движке Build на основе GZDoom называется просто Raze, а это версия для Android.