### PR TITLE
Zeta Touch: исправлены ссылки

### DIFF
--- a/DATA/Shadow_Warrior/Raze_Touch/links.md
+++ b/DATA/Shadow_Warrior/Raze_Touch/links.md
@@ -1,3 +1,3 @@
-[Скачать APK](https://github.com/emileb/Raze_Touch)
+[Скачать APK](http://opentouchgaming.com/zeta-touch/)
 
-[Github страница проекта](http://opentouchgaming.com/raze-touch)
+[Страница проекта на GitHub](https://github.com/emileb/Zeta_Touch)


### PR DESCRIPTION
Ссылка на скачивание APK устарела из-за переименования проекта; кроме того, подписи к ссылкам были перепутаны (ссылка якобы на GitHub вела на APK и наоборот).